### PR TITLE
Add read-only metadata audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ To skip loudness tagging entirely:
 python process_music.py /path/to/input /path/to/output --gain-mode none
 ```
 
+To run a read-only metadata audit without converting or copying audio:
+
+```bash
+python process_music.py /path/to/input /path/to/output --metadata-audit-only
+```
+
+This writes:
+
+- `metadata_audit.json`
+- `metadata_audit.md`
+
 - Your original files remain untouched.
 - The output folder will contain:
   - Original lossy files copied without generation loss
@@ -116,6 +127,8 @@ python process_music.py /path/to/input /path/to/output --gain-mode none
 - ReplayGain tags require player support. They do not modify MP3, AAC, or FLAC audio data.
 - `--gain-profile track` is intended for shuffled libraries and similar loudness across songs.
 - `--gain-profile album` preserves album-relative loudness and depends on album-per-folder organization.
+- `--metadata-audit-only` is read-only. It reports metadata problems but does not rename files or modify tags.
+- Personal canonical artist spellings can be added to `CANONICAL_ARTIST_OVERRIDES` in `musiclib/metadata_audit.py`, for example `Queens of the Stone Age`.
 - FLAC conversion preserves source sample rate and bit depth by default.
 - Lossy-to-lossy conversion is avoided by default because it reduces quality.
 - Metadata copying supports ID3, MP4, FLAC tags and embedded artwork (including cover art).

--- a/musiclib/metadata_audit.py
+++ b/musiclib/metadata_audit.py
@@ -1,0 +1,335 @@
+import json
+import os
+import re
+from collections import Counter, defaultdict
+
+from mutagen import File
+
+
+SUPPORTED_AUDIO_EXTENSIONS = {
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".alac",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".mp4",
+    ".ogg",
+    ".wav",
+    ".wma",
+}
+
+# Personal spelling overrides for names that generic title-casing handles poorly.
+CANONICAL_ARTIST_OVERRIDES = {
+    "queens of the stone age": "Queens of the Stone Age",
+}
+
+
+def _first_tag(audio, keys):
+    if not audio:
+        return None
+
+    for key in keys:
+        value = audio.get(key)
+        if not value:
+            continue
+        if isinstance(value, list):
+            value = value[0] if value else None
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+
+    return None
+
+
+def _normalize_text(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def _casefold(value):
+    return _normalize_text(value).casefold()
+
+
+def _parse_track_number(value):
+    if not value:
+        return None
+
+    if isinstance(value, tuple):
+        return value[0] if value else None
+
+    match = re.search(r"\d+", str(value))
+    if not match:
+        return None
+
+    return int(match.group(0))
+
+
+def _filename_stem(path):
+    return os.path.splitext(os.path.basename(path))[0]
+
+
+def _strip_track_prefix(name):
+    return re.sub(r"^\s*\d+\s*[-_. ]+\s*", "", name).strip()
+
+
+def _looks_like_title_match(filename, title):
+    if not filename or not title:
+        return False
+    normalized_filename = _casefold(_strip_track_prefix(filename))
+    normalized_title = _casefold(title)
+    return normalized_filename == normalized_title
+
+
+def read_track_metadata(path, root_dir):
+    audio = File(path, easy=True)
+    ext = os.path.splitext(path)[1].lower()
+    rel_path = os.path.relpath(path, root_dir)
+    track_raw = _first_tag(audio, ["tracknumber", "track"])
+
+    return {
+        "path": path,
+        "relative_path": rel_path,
+        "folder": os.path.dirname(rel_path),
+        "filename": os.path.basename(path),
+        "filename_stem": _filename_stem(path),
+        "ext": ext,
+        "title": _normalize_text(_first_tag(audio, ["title"])),
+        "artist": _normalize_text(_first_tag(audio, ["artist"])),
+        "album": _normalize_text(_first_tag(audio, ["album"])),
+        "album_artist": _normalize_text(_first_tag(audio, ["albumartist", "album artist"])),
+        "date": _normalize_text(_first_tag(audio, ["date", "year"])),
+        "genre": _normalize_text(_first_tag(audio, ["genre"])),
+        "track_number": _parse_track_number(track_raw),
+        "track_raw": _normalize_text(track_raw),
+    }
+
+
+def iter_audio_files(root_dir):
+    for root, _, files in os.walk(root_dir):
+        for filename in sorted(files):
+            ext = os.path.splitext(filename)[1].lower()
+            if ext in SUPPORTED_AUDIO_EXTENSIONS:
+                yield os.path.join(root, filename)
+
+
+def _issue(issue_type, severity, message, path=None, details=None):
+    return {
+        "type": issue_type,
+        "severity": severity,
+        "message": message,
+        "path": path,
+        "details": details or {},
+    }
+
+
+def _find_case_variants(tracks, field):
+    by_folded = defaultdict(Counter)
+    for track in tracks:
+        value = track.get(field)
+        if value:
+            by_folded[_casefold(value)][value] += 1
+
+    issues = []
+    for folded, variants in by_folded.items():
+        if folded and len(variants) > 1:
+            canonical = variants.most_common(1)[0][0]
+            issues.append(_issue(
+                f"{field}_case_variants",
+                "warning",
+                f"{field.replace('_', ' ').title()} has casing variants.",
+                details={
+                    "canonical_guess": canonical,
+                    "variants": dict(variants),
+                },
+            ))
+    return issues
+
+
+def _find_known_name_mismatches(tracks):
+    issues = []
+    for track in tracks:
+        for field in ["artist", "album_artist"]:
+            value = track.get(field)
+            if not value:
+                continue
+
+            canonical = CANONICAL_ARTIST_OVERRIDES.get(_casefold(value))
+            if canonical and value != canonical:
+                issues.append(_issue(
+                    f"{field}_known_name_mismatch",
+                    "info",
+                    f"{field.replace('_', ' ').title()} differs from known canonical spelling.",
+                    path=track["relative_path"],
+                    details={
+                        "value": value,
+                        "canonical": canonical,
+                    },
+                ))
+
+    return issues
+
+
+def _audit_track(track):
+    issues = []
+
+    if not track["title"]:
+        issues.append(_issue(
+            "missing_title",
+            "warning",
+            "Track is missing title metadata.",
+            path=track["relative_path"],
+        ))
+    elif not _looks_like_title_match(track["filename_stem"], track["title"]):
+        issues.append(_issue(
+            "filename_title_mismatch",
+            "info",
+            "Filename does not match title metadata after removing a leading track number.",
+            path=track["relative_path"],
+            details={
+                "filename": track["filename_stem"],
+                "title": track["title"],
+            },
+        ))
+
+    for field in ["artist", "album", "track_number"]:
+        if not track[field]:
+            issues.append(_issue(
+                f"missing_{field}",
+                "warning",
+                f"Track is missing {field.replace('_', ' ')} metadata.",
+                path=track["relative_path"],
+            ))
+
+    if not track["album_artist"]:
+        issues.append(_issue(
+            "missing_album_artist",
+            "info",
+            "Track is missing album artist metadata.",
+            path=track["relative_path"],
+        ))
+
+    return issues
+
+
+def _audit_folders(tracks):
+    issues = []
+    by_folder = defaultdict(list)
+    for track in tracks:
+        by_folder[track["folder"]].append(track)
+
+    for folder, folder_tracks in by_folder.items():
+        albums = {track["album"] for track in folder_tracks if track["album"]}
+        album_artists = {track["album_artist"] for track in folder_tracks if track["album_artist"]}
+        track_numbers = [
+            track["track_number"]
+            for track in folder_tracks
+            if track["track_number"] is not None
+        ]
+
+        if len(albums) > 1:
+            issues.append(_issue(
+                "mixed_album_names_in_folder",
+                "warning",
+                "Folder contains multiple album names.",
+                details={
+                    "folder": folder,
+                    "albums": sorted(albums),
+                },
+            ))
+
+        if len(album_artists) > 1:
+            issues.append(_issue(
+                "mixed_album_artists_in_folder",
+                "info",
+                "Folder contains multiple album artists.",
+                details={
+                    "folder": folder,
+                    "album_artists": sorted(album_artists),
+                },
+            ))
+
+        duplicates = [
+            number
+            for number, count in Counter(track_numbers).items()
+            if count > 1
+        ]
+        if duplicates:
+            issues.append(_issue(
+                "duplicate_track_numbers_in_folder",
+                "warning",
+                "Folder contains duplicate track numbers.",
+                details={
+                    "folder": folder,
+                    "track_numbers": duplicates,
+                },
+            ))
+
+    return issues
+
+
+def audit_metadata(root_dir):
+    tracks = [
+        read_track_metadata(path, root_dir)
+        for path in iter_audio_files(root_dir)
+    ]
+    issues = []
+
+    for track in tracks:
+        issues.extend(_audit_track(track))
+
+    issues.extend(_audit_folders(tracks))
+    for field in ["artist", "album", "album_artist", "genre"]:
+        issues.extend(_find_case_variants(tracks, field))
+    issues.extend(_find_known_name_mismatches(tracks))
+
+    return {
+        "root_dir": root_dir,
+        "track_count": len(tracks),
+        "issue_count": len(issues),
+        "tracks": tracks,
+        "issues": issues,
+    }
+
+
+def write_metadata_audit_reports(audit, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    json_path = os.path.join(output_dir, "metadata_audit.json")
+    md_path = os.path.join(output_dir, "metadata_audit.md")
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(audit, f, indent=2)
+
+    lines = [
+        "# Metadata Audit",
+        "",
+        f"- Root: `{audit['root_dir']}`",
+        f"- Tracks scanned: {audit['track_count']}",
+        f"- Issues found: {audit['issue_count']}",
+        "",
+        "| Severity | Type | Path | Message |",
+        "|----------|------|------|---------|",
+    ]
+
+    for issue in audit["issues"]:
+        lines.append(
+            f"| {_markdown_cell(issue['severity'])} | {_markdown_cell(issue['type'])} | "
+            f"{_markdown_cell(issue.get('path') or issue.get('details', {}).get('folder', ''))} | "
+            f"{_markdown_cell(issue['message'])} |"
+        )
+
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    return {
+        "json": json_path,
+        "markdown": md_path,
+    }
+
+
+def _markdown_cell(value):
+    return str(value).replace("|", "\\|").replace("\n", " ")

--- a/process_music.py
+++ b/process_music.py
@@ -22,6 +22,7 @@ from musiclib.analyze import (
     run_rsgain
 )
 from musiclib.artwork import extract_embedded_artwork
+from musiclib.metadata_audit import audit_metadata, write_metadata_audit_reports
 from musiclib.report import generate_reports
 
 FAILED_CONVERSION_DIR = "_failed_conversions"
@@ -259,6 +260,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MusicProcessor: Normalize and convert a music library.")
     parser.add_argument("input", help="Path to input directory")
     parser.add_argument("output", help="Path to output directory")
+    parser.add_argument(
+        "--metadata-audit-only",
+        action="store_true",
+        help="Only scan metadata and write metadata_audit reports; do not process audio.",
+    )
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
     parser.add_argument("--workers", type=int, default=None, help="Number of parallel workers to use")
     parser.add_argument(
@@ -275,6 +281,11 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    if args.metadata_audit_only:
+        reports = write_metadata_audit_reports(audit_metadata(args.input), args.output)
+        print(f"Metadata audit saved to:\n- {reports['json']}\n- {reports['markdown']}")
+        raise SystemExit(0)
 
     with prevent_system_sleep():
         process_library(

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -1,0 +1,125 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from musiclib.metadata_audit import audit_metadata, write_metadata_audit_reports
+
+
+def track(path, **overrides):
+    data = {
+        "path": path,
+        "relative_path": path,
+        "folder": os.path.dirname(path),
+        "filename": os.path.basename(path),
+        "filename_stem": os.path.splitext(os.path.basename(path))[0],
+        "ext": os.path.splitext(path)[1],
+        "title": "Song",
+        "artist": "Artist",
+        "album": "Album",
+        "album_artist": "Artist",
+        "date": "2000",
+        "genre": "Rock",
+        "track_number": 1,
+        "track_raw": "1",
+    }
+    data.update(overrides)
+    return data
+
+
+class MetadataAuditTests(unittest.TestCase):
+    def test_flags_known_artist_canonical_spelling(self):
+        tracks = [
+            track(
+                "Queens/Songs/01 - Song.mp3",
+                artist="queens of the stone age",
+                album_artist="Queens Of The Stone Age",
+            )
+        ]
+
+        with patch("musiclib.metadata_audit.iter_audio_files", return_value=["ignored.mp3"]), \
+                patch("musiclib.metadata_audit.read_track_metadata", side_effect=tracks):
+            audit = audit_metadata("/music")
+
+        issue_types = {issue["type"] for issue in audit["issues"]}
+        self.assertIn("artist_known_name_mismatch", issue_types)
+        self.assertIn("album_artist_known_name_mismatch", issue_types)
+
+    def test_flags_duplicate_track_numbers_in_folder(self):
+        tracks = [
+            track("Artist/Album/01 - A.mp3", title="A", track_number=1),
+            track("Artist/Album/01 - B.mp3", title="B", track_number=1),
+        ]
+
+        with patch("musiclib.metadata_audit.iter_audio_files", return_value=["a.mp3", "b.mp3"]), \
+                patch("musiclib.metadata_audit.read_track_metadata", side_effect=tracks):
+            audit = audit_metadata("/music")
+
+        self.assertIn(
+            "duplicate_track_numbers_in_folder",
+            {issue["type"] for issue in audit["issues"]},
+        )
+
+    def test_flags_missing_track_artist_even_when_album_artist_exists(self):
+        tracks = [
+            track("Artist/Album/01 - Song.mp3", artist="", album_artist="Artist"),
+        ]
+
+        with patch("musiclib.metadata_audit.iter_audio_files", return_value=["song.mp3"]), \
+                patch("musiclib.metadata_audit.read_track_metadata", side_effect=tracks):
+            audit = audit_metadata("/music")
+
+        self.assertIn("missing_artist", {issue["type"] for issue in audit["issues"]})
+
+    def test_writes_json_and_markdown_reports(self):
+        audit = {
+            "root_dir": "/music",
+            "track_count": 1,
+            "issue_count": 1,
+            "tracks": [],
+            "issues": [
+                {
+                    "type": "missing_title",
+                    "severity": "warning",
+                    "message": "Track is missing title metadata.",
+                    "path": "Artist/Album/01.mp3",
+                    "details": {},
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = write_metadata_audit_reports(audit, tmpdir)
+
+            self.assertTrue(os.path.exists(reports["json"]))
+            self.assertTrue(os.path.exists(reports["markdown"]))
+
+    def test_markdown_report_escapes_table_pipes(self):
+        audit = {
+            "root_dir": "/music",
+            "track_count": 1,
+            "issue_count": 1,
+            "tracks": [],
+            "issues": [
+                {
+                    "type": "filename_title_mismatch",
+                    "severity": "info",
+                    "message": "Filename has | in it.",
+                    "path": "Artist/Album/A | B.mp3",
+                    "details": {},
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = write_metadata_audit_reports(audit, tmpdir)
+
+            with open(reports["markdown"], encoding="utf-8") as f:
+                markdown = f.read()
+
+        self.assertIn("A \\| B.mp3", markdown)
+        self.assertIn("Filename has \\| in it.", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only metadata audit mode that writes JSON and Markdown reports
- flag missing metadata, filename/title mismatches, folder-level album inconsistencies, duplicate track numbers, casing variants, and personal canonical artist override mismatches
- document --metadata-audit-only and add unit coverage for audit/report behavior

## Tests
- /private/tmp/musicprocessor-venv/bin/python -m unittest discover -s tests
- git diff --check