### PR TITLE
Add dry-run filename normalization plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ This writes:
 - `metadata_audit.json`
 - `metadata_audit.md`
 
+To write a read-only filename normalization plan:
+
+```bash
+python process_music.py /path/to/input /path/to/output --filename-plan-only
+```
+
+This proposes filename-only changes like `01 - Track Title.mp3`, reports
+blocked actions such as missing title/track metadata or target filename
+collisions, and does not rename files.
+
 - Your original files remain untouched.
 - The output folder will contain:
   - Original lossy files copied without generation loss
@@ -128,6 +138,7 @@ This writes:
 - `--gain-profile track` is intended for shuffled libraries and similar loudness across songs.
 - `--gain-profile album` preserves album-relative loudness and depends on album-per-folder organization.
 - `--metadata-audit-only` is read-only. It reports metadata problems but does not rename files or modify tags.
+- `--filename-plan-only` is read-only. It proposes filename changes but does not apply them.
 - Personal canonical artist spellings can be added to `CANONICAL_ARTIST_OVERRIDES` in `musiclib/metadata_audit.py`, for example `Queens of the Stone Age`.
 - FLAC conversion preserves source sample rate and bit depth by default.
 - Lossy-to-lossy conversion is avoided by default because it reduces quality.

--- a/musiclib/metadata_audit.py
+++ b/musiclib/metadata_audit.py
@@ -333,3 +333,107 @@ def write_metadata_audit_reports(audit, output_dir):
 
 def _markdown_cell(value):
     return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _safe_filename_part(value):
+    value = _normalize_text(value)
+    value = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", value)
+    value = value.rstrip(" .")
+    return value or "Untitled"
+
+
+def _format_track_number(track_number):
+    if track_number is None:
+        return None
+    return f"{track_number:02d}"
+
+
+def build_filename_normalization_plan(audit):
+    """
+    Builds a read-only filename normalization plan from metadata audit data.
+
+    The plan proposes filename-only changes within each file's current folder.
+    It does not move folders or apply changes.
+    """
+    actions = []
+    target_counts = Counter()
+
+    for track in audit["tracks"]:
+        track_number = _format_track_number(track.get("track_number"))
+        title = track.get("title")
+
+        if not track_number or not title:
+            action = {
+                "status": "blocked",
+                "reason": "missing track number or title",
+                "path": track["relative_path"],
+                "proposed_path": None,
+                "current_filename": track["filename"],
+                "proposed_filename": None,
+            }
+        else:
+            proposed_filename = f"{track_number} - {_safe_filename_part(title)}{track['ext']}"
+            proposed_path = os.path.join(track["folder"], proposed_filename) if track["folder"] else proposed_filename
+            status = "no_change" if proposed_path == track["relative_path"] else "rename"
+            action = {
+                "status": status,
+                "reason": None,
+                "path": track["relative_path"],
+                "proposed_path": proposed_path,
+                "current_filename": track["filename"],
+                "proposed_filename": proposed_filename,
+            }
+            target_counts[proposed_path] += 1
+
+        actions.append(action)
+
+    for action in actions:
+        proposed_path = action.get("proposed_path")
+        if proposed_path and target_counts[proposed_path] > 1:
+            action["status"] = "blocked"
+            action["reason"] = "target filename collision"
+
+    return {
+        "root_dir": audit["root_dir"],
+        "track_count": audit["track_count"],
+        "rename_count": sum(1 for action in actions if action["status"] == "rename"),
+        "blocked_count": sum(1 for action in actions if action["status"] == "blocked"),
+        "actions": actions,
+    }
+
+
+def write_filename_plan_reports(plan, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    json_path = os.path.join(output_dir, "filename_normalization_plan.json")
+    md_path = os.path.join(output_dir, "filename_normalization_plan.md")
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(plan, f, indent=2)
+
+    lines = [
+        "# Filename Normalization Plan",
+        "",
+        f"- Root: `{plan['root_dir']}`",
+        f"- Tracks scanned: {plan['track_count']}",
+        f"- Proposed renames: {plan['rename_count']}",
+        f"- Blocked actions: {plan['blocked_count']}",
+        "",
+        "| Status | Current Path | Proposed Path | Reason |",
+        "|--------|--------------|---------------|--------|",
+    ]
+
+    for action in plan["actions"]:
+        lines.append(
+            f"| {_markdown_cell(action['status'])} | "
+            f"{_markdown_cell(action['path'])} | "
+            f"{_markdown_cell(action.get('proposed_path') or '')} | "
+            f"{_markdown_cell(action.get('reason') or '')} |"
+        )
+
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    return {
+        "json": json_path,
+        "markdown": md_path,
+    }

--- a/process_music.py
+++ b/process_music.py
@@ -22,7 +22,12 @@ from musiclib.analyze import (
     run_rsgain
 )
 from musiclib.artwork import extract_embedded_artwork
-from musiclib.metadata_audit import audit_metadata, write_metadata_audit_reports
+from musiclib.metadata_audit import (
+    audit_metadata,
+    build_filename_normalization_plan,
+    write_filename_plan_reports,
+    write_metadata_audit_reports,
+)
 from musiclib.report import generate_reports
 
 FAILED_CONVERSION_DIR = "_failed_conversions"
@@ -265,6 +270,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Only scan metadata and write metadata_audit reports; do not process audio.",
     )
+    parser.add_argument(
+        "--filename-plan-only",
+        action="store_true",
+        help="Only write a dry-run filename normalization plan; do not rename or process audio.",
+    )
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
     parser.add_argument("--workers", type=int, default=None, help="Number of parallel workers to use")
     parser.add_argument(
@@ -285,6 +295,12 @@ if __name__ == "__main__":
     if args.metadata_audit_only:
         reports = write_metadata_audit_reports(audit_metadata(args.input), args.output)
         print(f"Metadata audit saved to:\n- {reports['json']}\n- {reports['markdown']}")
+        raise SystemExit(0)
+
+    if args.filename_plan_only:
+        plan = build_filename_normalization_plan(audit_metadata(args.input))
+        reports = write_filename_plan_reports(plan, args.output)
+        print(f"Filename normalization plan saved to:\n- {reports['json']}\n- {reports['markdown']}")
         raise SystemExit(0)
 
     with prevent_system_sleep():

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -3,7 +3,12 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from musiclib.metadata_audit import audit_metadata, write_metadata_audit_reports
+from musiclib.metadata_audit import (
+    audit_metadata,
+    build_filename_normalization_plan,
+    write_filename_plan_reports,
+    write_metadata_audit_reports,
+)
 
 
 def track(path, **overrides):
@@ -119,6 +124,92 @@ class MetadataAuditTests(unittest.TestCase):
 
         self.assertIn("A \\| B.mp3", markdown)
         self.assertIn("Filename has \\| in it.", markdown)
+
+    def test_build_filename_plan_proposes_track_title_filename(self):
+        audit = {
+            "root_dir": "/music",
+            "track_count": 1,
+            "tracks": [
+                track(
+                    "Artist/Album/song.mp3",
+                    title="Go With the Flow",
+                    track_number=3,
+                )
+            ],
+            "issues": [],
+        }
+
+        plan = build_filename_normalization_plan(audit)
+
+        self.assertEqual(plan["rename_count"], 1)
+        self.assertEqual(
+            plan["actions"][0]["proposed_path"],
+            "Artist/Album/03 - Go With the Flow.mp3",
+        )
+
+    def test_build_filename_plan_sanitizes_invalid_filename_characters(self):
+        audit = {
+            "root_dir": "/music",
+            "track_count": 1,
+            "tracks": [
+                track(
+                    "Artist/Album/song.mp3",
+                    title='A/B: "C"?',
+                    track_number=1,
+                )
+            ],
+            "issues": [],
+        }
+
+        plan = build_filename_normalization_plan(audit)
+
+        self.assertEqual(
+            plan["actions"][0]["proposed_path"],
+            "Artist/Album/01 - A_B_ _C__.mp3",
+        )
+
+    def test_build_filename_plan_blocks_target_collisions(self):
+        audit = {
+            "root_dir": "/music",
+            "track_count": 2,
+            "tracks": [
+                track("Artist/Album/a.mp3", title="Song", track_number=1),
+                track("Artist/Album/b.mp3", title="Song", track_number=1),
+            ],
+            "issues": [],
+        }
+
+        plan = build_filename_normalization_plan(audit)
+
+        self.assertEqual(plan["blocked_count"], 2)
+        self.assertEqual(
+            {action["reason"] for action in plan["actions"]},
+            {"target filename collision"},
+        )
+
+    def test_writes_filename_plan_reports(self):
+        plan = {
+            "root_dir": "/music",
+            "track_count": 1,
+            "rename_count": 1,
+            "blocked_count": 0,
+            "actions": [
+                {
+                    "status": "rename",
+                    "reason": None,
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                    "current_filename": "song.mp3",
+                    "proposed_filename": "01 - Song.mp3",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = write_filename_plan_reports(plan, tmpdir)
+
+            self.assertTrue(os.path.exists(reports["json"]))
+            self.assertTrue(os.path.exists(reports["markdown"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add --filename-plan-only to write a read-only filename normalization plan
- propose filename-only changes using track number and title metadata
- block unsafe actions for missing metadata or target filename collisions
- document the new mode and add tests for planning, sanitization, collisions, and report writing

## Tests
- /private/tmp/musicprocessor-venv/bin/python -m unittest discover -s tests
- git diff --check