### PR TITLE
Apply filename normalization plans safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ This proposes filename-only changes like `01 - Track Title.mp3`, reports
 blocked actions such as missing title/track metadata or target filename
 collisions, and does not rename files.
 
+After reviewing the plan, apply valid rename actions:
+
+```bash
+python process_music.py /path/to/input /path/to/output --apply-filename-plan /path/to/output/filename_normalization_plan.json
+```
+
+By default, applying refuses to rename anything if the plan contains blocked
+actions. To apply valid rename actions while leaving blocked ones untouched:
+
+```bash
+python process_music.py /path/to/input /path/to/output --apply-filename-plan /path/to/output/filename_normalization_plan.json --allow-partial-renames
+```
+
+This writes `filename_normalization_results.json`.
+
 - Your original files remain untouched.
 - The output folder will contain:
   - Original lossy files copied without generation loss
@@ -139,6 +154,7 @@ collisions, and does not rename files.
 - `--gain-profile album` preserves album-relative loudness and depends on album-per-folder organization.
 - `--metadata-audit-only` is read-only. It reports metadata problems but does not rename files or modify tags.
 - `--filename-plan-only` is read-only. It proposes filename changes but does not apply them.
+- `--apply-filename-plan` only renames files within their current folders. It does not move folders or modify tags.
 - Personal canonical artist spellings can be added to `CANONICAL_ARTIST_OVERRIDES` in `musiclib/metadata_audit.py`, for example `Queens of the Stone Age`.
 - FLAC conversion preserves source sample rate and bit depth by default.
 - Lossy-to-lossy conversion is avoided by default because it reduces quality.

--- a/musiclib/metadata_audit.py
+++ b/musiclib/metadata_audit.py
@@ -437,3 +437,149 @@ def write_filename_plan_reports(plan, output_dir):
         "json": json_path,
         "markdown": md_path,
     }
+
+
+def apply_filename_normalization_plan(plan_path, allow_partial=False):
+    """
+    Applies rename actions from a filename normalization plan.
+
+    This only renames files within the plan root. It does not move folders,
+    write metadata, or apply blocked/no-change actions.
+    """
+    with open(plan_path, encoding="utf-8") as f:
+        plan = json.load(f)
+
+    root_dir = plan["root_dir"]
+    actions = plan.get("actions", [])
+    blocked_actions = [action for action in actions if action.get("status") == "blocked"]
+    results = []
+
+    if blocked_actions and not allow_partial:
+        for action in actions:
+            results.append({
+                "status": "skipped",
+                "reason": "plan contains blocked actions",
+                "path": action.get("path"),
+                "proposed_path": action.get("proposed_path"),
+            })
+        return _filename_apply_result(root_dir, results)
+
+    rename_actions = [action for action in actions if action.get("status") == "rename"]
+    target_counts = Counter(action.get("proposed_path") for action in rename_actions)
+
+    for action in actions:
+        if action.get("status") != "rename":
+            results.append({
+                "status": "skipped",
+                "reason": f"action status is {action.get('status')}",
+                "path": action.get("path"),
+                "proposed_path": action.get("proposed_path"),
+            })
+            continue
+
+        path = action.get("path")
+        proposed_path = action.get("proposed_path")
+        if target_counts[proposed_path] > 1:
+            results.append({
+                "status": "blocked",
+                "reason": "target filename collision",
+                "path": path,
+                "proposed_path": proposed_path,
+            })
+            continue
+
+        source = _resolve_plan_path(root_dir, path)
+        target = _resolve_plan_path(root_dir, proposed_path)
+        if os.path.dirname(source) != os.path.dirname(target):
+            results.append({
+                "status": "blocked",
+                "reason": "folder moves are not supported",
+                "path": path,
+                "proposed_path": proposed_path,
+            })
+            continue
+
+        if not os.path.exists(source):
+            results.append({
+                "status": "blocked",
+                "reason": "source file does not exist",
+                "path": path,
+                "proposed_path": proposed_path,
+            })
+            continue
+
+        if os.path.exists(target) and not _is_same_file(source, target):
+            results.append({
+                "status": "blocked",
+                "reason": "target file already exists",
+                "path": path,
+                "proposed_path": proposed_path,
+            })
+            continue
+
+        _rename_file(source, target)
+        results.append({
+            "status": "renamed",
+            "reason": None,
+            "path": path,
+            "proposed_path": proposed_path,
+        })
+
+    return _filename_apply_result(root_dir, results)
+
+
+def write_filename_apply_results(result, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    json_path = os.path.join(output_dir, "filename_normalization_results.json")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+    return json_path
+
+
+def _filename_apply_result(root_dir, results):
+    return {
+        "root_dir": root_dir,
+        "renamed_count": sum(1 for result in results if result["status"] == "renamed"),
+        "blocked_count": sum(1 for result in results if result["status"] == "blocked"),
+        "skipped_count": sum(1 for result in results if result["status"] == "skipped"),
+        "results": results,
+    }
+
+
+def _resolve_plan_path(root_dir, relative_path):
+    if not relative_path:
+        raise ValueError("Plan path is required")
+
+    root_abs = os.path.abspath(root_dir)
+    resolved = os.path.abspath(os.path.join(root_abs, relative_path))
+    if os.path.commonpath([root_abs, resolved]) != root_abs:
+        raise ValueError(f"Plan path escapes root: {relative_path}")
+    return resolved
+
+
+def _is_same_file(source, target):
+    try:
+        return os.path.samefile(source, target)
+    except FileNotFoundError:
+        return False
+
+
+def _rename_file(source, target):
+    if _is_same_file(source, target) and source != target:
+        temp = _case_rename_temp_path(source)
+        os.replace(source, temp)
+        os.replace(temp, target)
+        return
+
+    os.replace(source, target)
+
+
+def _case_rename_temp_path(source):
+    directory = os.path.dirname(source)
+    basename = os.path.basename(source)
+    candidate = os.path.join(directory, f".{basename}.rename-tmp")
+    counter = 1
+    while os.path.exists(candidate):
+        candidate = os.path.join(directory, f".{basename}.rename-tmp-{counter}")
+        counter += 1
+    return candidate

--- a/process_music.py
+++ b/process_music.py
@@ -24,7 +24,9 @@ from musiclib.analyze import (
 from musiclib.artwork import extract_embedded_artwork
 from musiclib.metadata_audit import (
     audit_metadata,
+    apply_filename_normalization_plan,
     build_filename_normalization_plan,
+    write_filename_apply_results,
     write_filename_plan_reports,
     write_metadata_audit_reports,
 )
@@ -275,6 +277,15 @@ if __name__ == "__main__":
         action="store_true",
         help="Only write a dry-run filename normalization plan; do not rename or process audio.",
     )
+    parser.add_argument(
+        "--apply-filename-plan",
+        help="Apply rename actions from a filename_normalization_plan.json file.",
+    )
+    parser.add_argument(
+        "--allow-partial-renames",
+        action="store_true",
+        help="Apply valid filename-plan renames even if the plan contains blocked actions.",
+    )
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
     parser.add_argument("--workers", type=int, default=None, help="Number of parallel workers to use")
     parser.add_argument(
@@ -301,6 +312,20 @@ if __name__ == "__main__":
         plan = build_filename_normalization_plan(audit_metadata(args.input))
         reports = write_filename_plan_reports(plan, args.output)
         print(f"Filename normalization plan saved to:\n- {reports['json']}\n- {reports['markdown']}")
+        raise SystemExit(0)
+
+    if args.apply_filename_plan:
+        result = apply_filename_normalization_plan(
+            args.apply_filename_plan,
+            allow_partial=args.allow_partial_renames,
+        )
+        result_path = write_filename_apply_results(result, args.output)
+        print(f"Filename normalization results saved to:\n- {result_path}")
+        print(
+            f"Renamed: {result['renamed_count']}; "
+            f"Blocked: {result['blocked_count']}; "
+            f"Skipped: {result['skipped_count']}"
+        )
         raise SystemExit(0)
 
     with prevent_system_sleep():

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -1,11 +1,14 @@
 import os
+import json
 import tempfile
 import unittest
 from unittest.mock import patch
 
 from musiclib.metadata_audit import (
     audit_metadata,
+    apply_filename_normalization_plan,
     build_filename_normalization_plan,
+    write_filename_apply_results,
     write_filename_plan_reports,
     write_metadata_audit_reports,
 )
@@ -30,6 +33,20 @@ def track(path, **overrides):
     }
     data.update(overrides)
     return data
+
+
+def write_plan(root_dir, actions):
+    plan = {
+        "root_dir": root_dir,
+        "track_count": len(actions),
+        "rename_count": sum(1 for action in actions if action["status"] == "rename"),
+        "blocked_count": sum(1 for action in actions if action["status"] == "blocked"),
+        "actions": actions,
+    }
+    plan_path = os.path.join(root_dir, "filename_normalization_plan.json")
+    with open(plan_path, "w", encoding="utf-8") as f:
+        json.dump(plan, f)
+    return plan_path
 
 
 class MetadataAuditTests(unittest.TestCase):
@@ -210,6 +227,149 @@ class MetadataAuditTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(reports["json"]))
             self.assertTrue(os.path.exists(reports["markdown"]))
+
+    def test_apply_filename_plan_renames_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            target = os.path.join(album_dir, "01 - Song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                }
+            ])
+
+            result = apply_filename_normalization_plan(plan_path)
+
+            self.assertEqual(result["renamed_count"], 1)
+            self.assertFalse(os.path.exists(source))
+            self.assertTrue(os.path.exists(target))
+
+    def test_apply_filename_plan_refuses_blocked_plan_by_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                },
+                {
+                    "status": "blocked",
+                    "path": "Artist/Album/other.mp3",
+                    "proposed_path": None,
+                },
+            ])
+
+            result = apply_filename_normalization_plan(plan_path)
+
+            self.assertEqual(result["renamed_count"], 0)
+            self.assertEqual(result["skipped_count"], 2)
+            self.assertTrue(os.path.exists(source))
+
+    def test_apply_filename_plan_allows_partial_renames(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            target = os.path.join(album_dir, "01 - Song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                },
+                {
+                    "status": "blocked",
+                    "path": "Artist/Album/other.mp3",
+                    "proposed_path": None,
+                },
+            ])
+
+            result = apply_filename_normalization_plan(plan_path, allow_partial=True)
+
+            self.assertEqual(result["renamed_count"], 1)
+            self.assertEqual(result["skipped_count"], 1)
+            self.assertFalse(os.path.exists(source))
+            self.assertTrue(os.path.exists(target))
+
+    def test_apply_filename_plan_blocks_existing_target(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            target = os.path.join(album_dir, "01 - Song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            open(target, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                }
+            ])
+
+            result = apply_filename_normalization_plan(plan_path)
+
+            self.assertEqual(result["blocked_count"], 1)
+            self.assertEqual(result["results"][0]["reason"], "target file already exists")
+            self.assertTrue(os.path.exists(source))
+
+    def test_apply_filename_plan_allows_case_only_renames(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/Song.mp3",
+                }
+            ])
+
+            with patch("musiclib.metadata_audit._is_same_file", return_value=True), \
+                    patch("musiclib.metadata_audit._rename_file") as rename_file:
+                result = apply_filename_normalization_plan(plan_path)
+
+            self.assertEqual(result["renamed_count"], 1)
+            rename_file.assert_called_once()
+
+    def test_apply_filename_plan_rejects_paths_outside_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "../song.mp3",
+                    "proposed_path": "01 - Song.mp3",
+                }
+            ])
+
+            with self.assertRaises(ValueError):
+                apply_filename_normalization_plan(plan_path)
+
+    def test_writes_filename_apply_results(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = {
+                "root_dir": "/music",
+                "renamed_count": 1,
+                "blocked_count": 0,
+                "skipped_count": 0,
+                "results": [],
+            }
+
+            result_path = write_filename_apply_results(result, tmpdir)
+
+            self.assertTrue(os.path.exists(result_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add --apply-filename-plan to apply rename actions from filename_normalization_plan.json
- refuse plans with blocked actions by default, with --allow-partial-renames for valid partial application
- revalidate source existence, target collisions, folder-move attempts, and root path escapes at apply time
- handle case-only renames on case-insensitive filesystems with a temporary filename hop
- write filename_normalization_results.json and document the workflow

## Tests
- /private/tmp/musicprocessor-venv/bin/python -m unittest discover -s tests
- git diff --check