### PR TITLE
Preflight filename plan application

### DIFF
--- a/musiclib/metadata_audit.py
+++ b/musiclib/metadata_audit.py
@@ -464,8 +464,26 @@ def apply_filename_normalization_plan(plan_path, allow_partial=False):
             })
         return _filename_apply_result(root_dir, results)
 
-    rename_actions = [action for action in actions if action.get("status") == "rename"]
-    target_counts = Counter(action.get("proposed_path") for action in rename_actions)
+    preflight_results = _preflight_filename_renames(root_dir, actions)
+    runtime_blockers = [
+        result
+        for result in preflight_results.values()
+        if result["status"] == "blocked"
+    ]
+
+    if runtime_blockers and not allow_partial:
+        for action in actions:
+            result = preflight_results.get(id(action))
+            if result and result["status"] == "blocked":
+                results.append(result)
+            else:
+                results.append({
+                    "status": "skipped",
+                    "reason": "plan contains runtime blockers",
+                    "path": action.get("path"),
+                    "proposed_path": action.get("proposed_path"),
+                })
+        return _filename_apply_result(root_dir, results)
 
     for action in actions:
         if action.get("status") != "rename":
@@ -477,45 +495,15 @@ def apply_filename_normalization_plan(plan_path, allow_partial=False):
             })
             continue
 
+        preflight = preflight_results[id(action)]
+        if preflight["status"] == "blocked":
+            results.append(preflight)
+            continue
+
         path = action.get("path")
         proposed_path = action.get("proposed_path")
-        if target_counts[proposed_path] > 1:
-            results.append({
-                "status": "blocked",
-                "reason": "target filename collision",
-                "path": path,
-                "proposed_path": proposed_path,
-            })
-            continue
-
-        source = _resolve_plan_path(root_dir, path)
-        target = _resolve_plan_path(root_dir, proposed_path)
-        if os.path.dirname(source) != os.path.dirname(target):
-            results.append({
-                "status": "blocked",
-                "reason": "folder moves are not supported",
-                "path": path,
-                "proposed_path": proposed_path,
-            })
-            continue
-
-        if not os.path.exists(source):
-            results.append({
-                "status": "blocked",
-                "reason": "source file does not exist",
-                "path": path,
-                "proposed_path": proposed_path,
-            })
-            continue
-
-        if os.path.exists(target) and not _is_same_file(source, target):
-            results.append({
-                "status": "blocked",
-                "reason": "target file already exists",
-                "path": path,
-                "proposed_path": proposed_path,
-            })
-            continue
+        source = preflight["source"]
+        target = preflight["target"]
 
         _rename_file(source, target)
         results.append({
@@ -526,6 +514,59 @@ def apply_filename_normalization_plan(plan_path, allow_partial=False):
         })
 
     return _filename_apply_result(root_dir, results)
+
+
+def _preflight_filename_renames(root_dir, actions):
+    rename_actions = [action for action in actions if action.get("status") == "rename"]
+    target_counts = Counter(action.get("proposed_path") for action in rename_actions)
+    results = {}
+
+    for action in rename_actions:
+        path = action.get("path")
+        proposed_path = action.get("proposed_path")
+
+        if target_counts[proposed_path] > 1:
+            results[id(action)] = _apply_blocker(action, "target filename collision")
+            continue
+
+        try:
+            source = _resolve_plan_path(root_dir, path)
+            target = _resolve_plan_path(root_dir, proposed_path)
+        except ValueError as e:
+            results[id(action)] = _apply_blocker(action, str(e))
+            continue
+
+        if os.path.dirname(source) != os.path.dirname(target):
+            results[id(action)] = _apply_blocker(action, "folder moves are not supported")
+            continue
+
+        if not os.path.exists(source):
+            results[id(action)] = _apply_blocker(action, "source file does not exist")
+            continue
+
+        if os.path.exists(target) and not _is_same_file(source, target):
+            results[id(action)] = _apply_blocker(action, "target file already exists")
+            continue
+
+        results[id(action)] = {
+            "status": "ready",
+            "reason": None,
+            "path": path,
+            "proposed_path": proposed_path,
+            "source": source,
+            "target": target,
+        }
+
+    return results
+
+
+def _apply_blocker(action, reason):
+    return {
+        "status": "blocked",
+        "reason": reason,
+        "path": action.get("path"),
+        "proposed_path": action.get("proposed_path"),
+    }
 
 
 def write_filename_apply_results(result, output_dir):

--- a/process_music.py
+++ b/process_music.py
@@ -302,6 +302,16 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    selected_special_modes = [
+        args.metadata_audit_only,
+        args.filename_plan_only,
+        bool(args.apply_filename_plan),
+    ]
+    if sum(selected_special_modes) > 1:
+        parser.error(
+            "Choose only one of --metadata-audit-only, --filename-plan-only, "
+            "or --apply-filename-plan."
+        )
 
     if args.metadata_audit_only:
         reports = write_metadata_audit_reports(audit_metadata(args.input), args.output)

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -274,6 +274,32 @@ class MetadataAuditTests(unittest.TestCase):
             self.assertEqual(result["skipped_count"], 2)
             self.assertTrue(os.path.exists(source))
 
+    def test_apply_filename_plan_refuses_runtime_blockers_by_default_before_renaming(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                },
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/missing.mp3",
+                    "proposed_path": "Artist/Album/02 - Missing.mp3",
+                },
+            ])
+
+            result = apply_filename_normalization_plan(plan_path)
+
+            self.assertEqual(result["renamed_count"], 0)
+            self.assertEqual(result["blocked_count"], 1)
+            self.assertEqual(result["skipped_count"], 1)
+            self.assertTrue(os.path.exists(source))
+
     def test_apply_filename_plan_allows_partial_renames(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             album_dir = os.path.join(tmpdir, "Artist", "Album")
@@ -354,8 +380,36 @@ class MetadataAuditTests(unittest.TestCase):
                 }
             ])
 
-            with self.assertRaises(ValueError):
-                apply_filename_normalization_plan(plan_path)
+            result = apply_filename_normalization_plan(plan_path)
+
+            self.assertEqual(result["blocked_count"], 1)
+            self.assertIn("escapes root", result["results"][0]["reason"])
+
+    def test_apply_filename_plan_partial_mode_reports_path_escape_without_aborting(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            album_dir = os.path.join(tmpdir, "Artist", "Album")
+            os.makedirs(album_dir)
+            source = os.path.join(album_dir, "song.mp3")
+            target = os.path.join(album_dir, "01 - Song.mp3")
+            open(source, "w", encoding="utf-8").close()
+            plan_path = write_plan(tmpdir, [
+                {
+                    "status": "rename",
+                    "path": "Artist/Album/song.mp3",
+                    "proposed_path": "Artist/Album/01 - Song.mp3",
+                },
+                {
+                    "status": "rename",
+                    "path": "../bad.mp3",
+                    "proposed_path": "bad.mp3",
+                },
+            ])
+
+            result = apply_filename_normalization_plan(plan_path, allow_partial=True)
+
+            self.assertEqual(result["renamed_count"], 1)
+            self.assertEqual(result["blocked_count"], 1)
+            self.assertTrue(os.path.exists(target))
 
     def test_writes_filename_apply_results(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- preflight all filename-plan rename actions before applying default all-or-nothing mode
- convert path escapes and runtime blockers into blocked results instead of mid-apply exceptions
- reject conflicting special CLI modes explicitly
- add coverage for runtime blockers, path escapes, and partial application behavior

## Tests
- /private/tmp/musicprocessor-venv/bin/python -m unittest discover -s tests
- git diff --check