### PR TITLE
Refactor CLI into subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,33 +46,33 @@ brew install ffmpeg rsgain
 ## 🚀 Usage
 
 ```bash
-python process_music.py /path/to/input /path/to/output
+python process_music.py process /path/to/input /path/to/output
 ```
 
 By default, MusicProcessor uses track ReplayGain tags, which is the best fit
 for shuffle playback and making songs land at a similar perceived loudness.
 
 ```bash
-python process_music.py /path/to/input /path/to/output --gain-profile track
+python process_music.py process /path/to/input /path/to/output --gain-profile track
 ```
 
 For album playback, use album mode. This writes album gain tags in addition to
 track gain tags and assumes each album is contained in its own folder.
 
 ```bash
-python process_music.py /path/to/input /path/to/output --gain-profile album
+python process_music.py process /path/to/input /path/to/output --gain-profile album
 ```
 
 To skip loudness tagging entirely:
 
 ```bash
-python process_music.py /path/to/input /path/to/output --gain-mode none
+python process_music.py process /path/to/input /path/to/output --gain-mode none
 ```
 
 To run a read-only metadata audit without converting or copying audio:
 
 ```bash
-python process_music.py /path/to/input /path/to/output --metadata-audit-only
+python process_music.py metadata-audit /path/to/input /path/to/output
 ```
 
 This writes:
@@ -83,7 +83,7 @@ This writes:
 To write a read-only filename normalization plan:
 
 ```bash
-python process_music.py /path/to/input /path/to/output --filename-plan-only
+python process_music.py filename-plan /path/to/input /path/to/output
 ```
 
 This proposes filename-only changes like `01 - Track Title.mp3`, reports
@@ -93,14 +93,14 @@ collisions, and does not rename files.
 After reviewing the plan, apply valid rename actions:
 
 ```bash
-python process_music.py /path/to/input /path/to/output --apply-filename-plan /path/to/output/filename_normalization_plan.json
+python process_music.py apply-filename-plan /path/to/output/filename_normalization_plan.json /path/to/output
 ```
 
 By default, applying refuses to rename anything if the plan contains blocked
 actions. To apply valid rename actions while leaving blocked ones untouched:
 
 ```bash
-python process_music.py /path/to/input /path/to/output --apply-filename-plan /path/to/output/filename_normalization_plan.json --allow-partial-renames
+python process_music.py apply-filename-plan /path/to/output/filename_normalization_plan.json /path/to/output --allow-partial-renames
 ```
 
 This writes `filename_normalization_results.json`.
@@ -152,9 +152,9 @@ This writes `filename_normalization_results.json`.
 - ReplayGain tags require player support. They do not modify MP3, AAC, or FLAC audio data.
 - `--gain-profile track` is intended for shuffled libraries and similar loudness across songs.
 - `--gain-profile album` preserves album-relative loudness and depends on album-per-folder organization.
-- `--metadata-audit-only` is read-only. It reports metadata problems but does not rename files or modify tags.
-- `--filename-plan-only` is read-only. It proposes filename changes but does not apply them.
-- `--apply-filename-plan` only renames files within their current folders. It does not move folders or modify tags.
+- `metadata-audit` is read-only. It reports metadata problems but does not rename files or modify tags.
+- `filename-plan` is read-only. It proposes filename changes but does not apply them.
+- `apply-filename-plan` only renames files within their current folders. It does not move folders or modify tags.
 - Personal canonical artist spellings can be added to `CANONICAL_ARTIST_OVERRIDES` in `musiclib/metadata_audit.py`, for example `Queens of the Stone Age`.
 - FLAC conversion preserves source sample rate and bit depth by default.
 - Lossy-to-lossy conversion is avoided by default because it reduces quality.

--- a/process_music.py
+++ b/process_music.py
@@ -263,81 +263,7 @@ def process_library(
     print(f"Files that failed to convert copied to: {failed_dir}")
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="MusicProcessor: Normalize and convert a music library.")
-    parser.add_argument("input", help="Path to input directory")
-    parser.add_argument("output", help="Path to output directory")
-    parser.add_argument(
-        "--metadata-audit-only",
-        action="store_true",
-        help="Only scan metadata and write metadata_audit reports; do not process audio.",
-    )
-    parser.add_argument(
-        "--filename-plan-only",
-        action="store_true",
-        help="Only write a dry-run filename normalization plan; do not rename or process audio.",
-    )
-    parser.add_argument(
-        "--apply-filename-plan",
-        help="Apply rename actions from a filename_normalization_plan.json file.",
-    )
-    parser.add_argument(
-        "--allow-partial-renames",
-        action="store_true",
-        help="Apply valid filename-plan renames even if the plan contains blocked actions.",
-    )
-    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
-    parser.add_argument("--workers", type=int, default=None, help="Number of parallel workers to use")
-    parser.add_argument(
-        "--gain-mode",
-        choices=["tags", "none"],
-        default="tags",
-        help="How to normalize loudness. 'tags' writes ReplayGain metadata without changing audio.",
-    )
-    parser.add_argument(
-        "--gain-profile",
-        choices=["track", "album"],
-        default="track",
-        help="'track' targets similar song loudness for shuffle. 'album' also writes album gain tags.",
-    )
-
-    args = parser.parse_args()
-    selected_special_modes = [
-        args.metadata_audit_only,
-        args.filename_plan_only,
-        bool(args.apply_filename_plan),
-    ]
-    if sum(selected_special_modes) > 1:
-        parser.error(
-            "Choose only one of --metadata-audit-only, --filename-plan-only, "
-            "or --apply-filename-plan."
-        )
-
-    if args.metadata_audit_only:
-        reports = write_metadata_audit_reports(audit_metadata(args.input), args.output)
-        print(f"Metadata audit saved to:\n- {reports['json']}\n- {reports['markdown']}")
-        raise SystemExit(0)
-
-    if args.filename_plan_only:
-        plan = build_filename_normalization_plan(audit_metadata(args.input))
-        reports = write_filename_plan_reports(plan, args.output)
-        print(f"Filename normalization plan saved to:\n- {reports['json']}\n- {reports['markdown']}")
-        raise SystemExit(0)
-
-    if args.apply_filename_plan:
-        result = apply_filename_normalization_plan(
-            args.apply_filename_plan,
-            allow_partial=args.allow_partial_renames,
-        )
-        result_path = write_filename_apply_results(result, args.output)
-        print(f"Filename normalization results saved to:\n- {result_path}")
-        print(
-            f"Renamed: {result['renamed_count']}; "
-            f"Blocked: {result['blocked_count']}; "
-            f"Skipped: {result['skipped_count']}"
-        )
-        raise SystemExit(0)
-
+def run_process_command(args):
     with prevent_system_sleep():
         process_library(
             args.input,
@@ -347,3 +273,84 @@ if __name__ == "__main__":
             gain_mode=args.gain_mode,
             gain_profile=args.gain_profile,
         )
+
+
+def run_metadata_audit_command(args):
+    reports = write_metadata_audit_reports(audit_metadata(args.input), args.output)
+    print(f"Metadata audit saved to:\n- {reports['json']}\n- {reports['markdown']}")
+
+
+def run_filename_plan_command(args):
+    plan = build_filename_normalization_plan(audit_metadata(args.input))
+    reports = write_filename_plan_reports(plan, args.output)
+    print(f"Filename normalization plan saved to:\n- {reports['json']}\n- {reports['markdown']}")
+
+
+def run_apply_filename_plan_command(args):
+    result = apply_filename_normalization_plan(
+        args.plan,
+        allow_partial=args.allow_partial_renames,
+    )
+    result_path = write_filename_apply_results(result, args.output)
+    print(f"Filename normalization results saved to:\n- {result_path}")
+    print(
+        f"Renamed: {result['renamed_count']}; "
+        f"Blocked: {result['blocked_count']}; "
+        f"Skipped: {result['skipped_count']}"
+    )
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="MusicProcessor: process and maintain a music library.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    process_parser = subparsers.add_parser("process", help="Process, normalize, analyze, and report a music library.")
+    process_parser.add_argument("input", help="Path to input directory")
+    process_parser.add_argument("output", help="Path to output directory")
+    process_parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
+    process_parser.add_argument("--workers", type=int, default=None, help="Number of parallel workers to use")
+    process_parser.add_argument(
+        "--gain-mode",
+        choices=["tags", "none"],
+        default="tags",
+        help="How to normalize loudness. 'tags' writes ReplayGain metadata without changing audio.",
+    )
+    process_parser.add_argument(
+        "--gain-profile",
+        choices=["track", "album"],
+        default="track",
+        help="'track' targets similar song loudness for shuffle. 'album' also writes album gain tags.",
+    )
+    process_parser.set_defaults(handler=run_process_command)
+
+    metadata_parser = subparsers.add_parser("metadata-audit", help="Write read-only metadata audit reports.")
+    metadata_parser.add_argument("input", help="Path to input directory")
+    metadata_parser.add_argument("output", help="Path to output directory")
+    metadata_parser.set_defaults(handler=run_metadata_audit_command)
+
+    filename_plan_parser = subparsers.add_parser("filename-plan", help="Write a read-only filename normalization plan.")
+    filename_plan_parser.add_argument("input", help="Path to input directory")
+    filename_plan_parser.add_argument("output", help="Path to output directory")
+    filename_plan_parser.set_defaults(handler=run_filename_plan_command)
+
+    apply_parser = subparsers.add_parser("apply-filename-plan", help="Apply rename actions from a filename plan.")
+    apply_parser.add_argument("plan", help="Path to filename_normalization_plan.json")
+    apply_parser.add_argument("output", help="Path to write filename_normalization_results.json")
+    apply_parser.add_argument(
+        "--allow-partial-renames",
+        action="store_true",
+        help="Apply valid filename-plan renames even if the plan contains blocked actions.",
+    )
+    apply_parser.set_defaults(handler=run_apply_filename_plan_command)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_process_music_cli.py
+++ b/tests/test_process_music_cli.py
@@ -1,0 +1,61 @@
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+
+from process_music import build_parser
+
+
+class ProcessMusicCliTests(unittest.TestCase):
+    def test_process_subcommand_parses_processing_options(self):
+        args = build_parser().parse_args([
+            "process",
+            "input",
+            "output",
+            "--overwrite",
+            "--workers",
+            "2",
+            "--gain-mode",
+            "none",
+        ])
+
+        self.assertEqual(args.command, "process")
+        self.assertEqual(args.input, "input")
+        self.assertEqual(args.output, "output")
+        self.assertTrue(args.overwrite)
+        self.assertEqual(args.workers, 2)
+        self.assertEqual(args.gain_mode, "none")
+
+    def test_metadata_audit_subcommand_parses_paths(self):
+        args = build_parser().parse_args(["metadata-audit", "input", "output"])
+
+        self.assertEqual(args.command, "metadata-audit")
+        self.assertEqual(args.input, "input")
+        self.assertEqual(args.output, "output")
+
+    def test_filename_plan_subcommand_parses_paths(self):
+        args = build_parser().parse_args(["filename-plan", "input", "output"])
+
+        self.assertEqual(args.command, "filename-plan")
+        self.assertEqual(args.input, "input")
+        self.assertEqual(args.output, "output")
+
+    def test_apply_filename_plan_subcommand_parses_plan_and_output(self):
+        args = build_parser().parse_args([
+            "apply-filename-plan",
+            "filename_normalization_plan.json",
+            "output",
+            "--allow-partial-renames",
+        ])
+
+        self.assertEqual(args.command, "apply-filename-plan")
+        self.assertEqual(args.plan, "filename_normalization_plan.json")
+        self.assertEqual(args.output, "output")
+        self.assertTrue(args.allow_partial_renames)
+
+    def test_legacy_no_subcommand_form_is_rejected(self):
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+            build_parser().parse_args(["input", "output"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace legacy mode flags with explicit subcommands: process, metadata-audit, filename-plan, and apply-filename-plan
- move command dispatch into testable handler functions and parser construction
- update README examples to the new subcommand-only interface
- add parser tests for each command and confirm the old no-subcommand form is rejected

## Tests
- /private/tmp/musicprocessor-venv/bin/python -m compileall process_music.py musiclib tests
- /private/tmp/musicprocessor-venv/bin/python -m unittest discover -s tests
- git diff --check