### PR TITLE
Add read-only quality audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ This writes:
 - `metadata_audit.json`
 - `metadata_audit.md`
 
+To run a read-only quality audit for files that may need re-sourcing:
+
+```bash
+python process_music.py quality-audit /path/to/input /path/to/output
+```
+
+This writes:
+
+- `quality_audit.json`
+- `quality_audit.md`
+
+The quality audit flags low-bitrate lossy files, suspicious low-bitrate FLACs,
+low sample rates, very short tracks, potential clipping, decode errors, and
+missing ReplayGain tags.
+
 To write a read-only filename normalization plan:
 
 ```bash
@@ -153,6 +168,7 @@ This writes `filename_normalization_results.json`.
 - `--gain-profile track` is intended for shuffled libraries and similar loudness across songs.
 - `--gain-profile album` preserves album-relative loudness and depends on album-per-folder organization.
 - `metadata-audit` is read-only. It reports metadata problems but does not rename files or modify tags.
+- `quality-audit` is read-only. It reports likely source-quality problems but does not modify files.
 - `filename-plan` is read-only. It proposes filename changes but does not apply them.
 - `apply-filename-plan` only renames files within their current folders. It does not move folders or modify tags.
 - Personal canonical artist spellings can be added to `CANONICAL_ARTIST_OVERRIDES` in `musiclib/metadata_audit.py`, for example `Queens of the Stone Age`.

--- a/musiclib/analyze.py
+++ b/musiclib/analyze.py
@@ -1,6 +1,26 @@
+import json
 import os
 import subprocess
 from mutagen import File
+
+
+LOW_BITRATE_LOSSY_KBPS = 192
+SUSPICIOUS_FLAC_BITRATE_KBPS = 700
+LOW_SAMPLE_RATE_HZ = 44100
+NON_RESOURCING_QUALITY_REASONS = {"missing_replaygain", "very_short_track"}
+QUALITY_AUDIO_EXTENSIONS = {
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".alac",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".mp4",
+    ".ogg",
+    ".wav",
+    ".wma",
+}
 
 
 def run_rsgain(directory, gain_profile="track", threads=4):
@@ -129,6 +149,161 @@ def analyze_gain(filepath):
         })
         result["resourcing_recommended"] = result["too_quiet"] or result["potential_clipping"]
     return result
+
+
+def is_lossless_audio(audio_info):
+    return _is_lossless_codec(audio_info) or audio_info.get("ext") in [".alac", ".wav", ".aiff", ".aif"]
+
+
+def analyze_quality(filepath, root_dir=None):
+    try:
+        audio_info = get_audio_info(filepath)
+        read_error = None
+    except Exception as e:
+        audio_info = _empty_audio_info(filepath)
+        read_error = str(e)
+
+    try:
+        gain_info = analyze_gain(filepath)
+    except Exception:
+        gain_info = _empty_gain_info(filepath)
+
+    reasons = []
+    ext = audio_info.get("ext")
+    bitrate = audio_info.get("bitrate")
+    sample_rate = audio_info.get("sample_rate")
+    duration = audio_info.get("duration")
+    parser = audio_info.get("parser")
+    is_lossless = is_lossless_audio(audio_info)
+
+    if parser is None:
+        reasons.append("decode_error")
+    if bitrate is not None and not is_lossless and bitrate < LOW_BITRATE_LOSSY_KBPS:
+        reasons.append("low_bitrate_lossy")
+    if ext == ".flac" and bitrate is not None and bitrate < SUSPICIOUS_FLAC_BITRATE_KBPS:
+        reasons.append("suspicious_lossless_bitrate")
+    if sample_rate is not None and sample_rate < LOW_SAMPLE_RATE_HZ:
+        reasons.append("low_sample_rate")
+    if duration is not None and duration < 30:
+        reasons.append("very_short_track")
+    if gain_info["potential_clipping"]:
+        reasons.append("potential_clipping")
+    if gain_info["track_gain"] is None:
+        reasons.append("missing_replaygain")
+
+    return {
+        "path": filepath,
+        "relative_path": os.path.relpath(filepath, root_dir) if root_dir else filepath,
+        "ext": ext,
+        "codec": audio_info.get("codec"),
+        "codec_description": audio_info.get("codec_description"),
+        "parser": parser,
+        "bitrate": bitrate,
+        "sample_rate": sample_rate,
+        "bits_per_sample": audio_info.get("bits_per_sample"),
+        "duration": duration,
+        "is_lossless": is_lossless,
+        "track_gain": gain_info["track_gain"],
+        "track_peak": gain_info["track_peak"],
+        "album_gain": gain_info["album_gain"],
+        "album_peak": gain_info["album_peak"],
+        "resourcing_recommended": any(
+            reason not in NON_RESOURCING_QUALITY_REASONS
+            for reason in reasons
+        ),
+        "error": read_error,
+        "reasons": reasons,
+    }
+
+
+def _empty_audio_info(filepath):
+    return {
+        "ext": os.path.splitext(filepath)[1].lower(),
+        "sample_rate": None,
+        "bits_per_sample": None,
+        "bitrate": None,
+        "duration": None,
+        "codec": None,
+        "codec_description": None,
+        "parser": None,
+    }
+
+
+def _empty_gain_info(filepath):
+    return {
+        "path": filepath,
+        "track_gain": None,
+        "album_gain": None,
+        "track_peak": None,
+        "album_peak": None,
+        "too_quiet": False,
+        "potential_clipping": False,
+        "resourcing_recommended": False,
+    }
+
+
+def audit_quality(root_dir):
+    tracks = [
+        analyze_quality(path, root_dir=root_dir)
+        for path in iter_quality_audio_files(root_dir)
+    ]
+    flagged = [track for track in tracks if track["resourcing_recommended"]]
+    return {
+        "root_dir": root_dir,
+        "track_count": len(tracks),
+        "flagged_count": len(flagged),
+        "tracks": tracks,
+    }
+
+
+def iter_quality_audio_files(root_dir):
+    for root, _, files in os.walk(root_dir):
+        for filename in sorted(files):
+            ext = os.path.splitext(filename)[1].lower()
+            if ext in QUALITY_AUDIO_EXTENSIONS:
+                yield os.path.join(root, filename)
+
+
+def write_quality_audit_reports(audit, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    json_path = os.path.join(output_dir, "quality_audit.json")
+    md_path = os.path.join(output_dir, "quality_audit.md")
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(audit, f, indent=2)
+
+    lines = [
+        "# Quality Audit",
+        "",
+        f"- Root: `{audit['root_dir']}`",
+        f"- Tracks scanned: {audit['track_count']}",
+        f"- Resourcing recommended: {audit['flagged_count']}",
+        "",
+        "| Resourcing | Path | Codec | Bitrate | Sample Rate | Reasons |",
+        "|------------|------|-------|---------|-------------|---------|",
+    ]
+
+    for track in audit["tracks"]:
+        lines.append(
+            f"| {track['resourcing_recommended']} | "
+            f"{_markdown_cell(track['relative_path'])} | "
+            f"{_markdown_cell(track.get('codec_description') or track.get('codec') or track.get('parser') or '')} | "
+            f"{_markdown_cell(track.get('bitrate') or '')} | "
+            f"{_markdown_cell(track.get('sample_rate') or '')} | "
+            f"{_markdown_cell(', '.join(track['reasons']))} |"
+        )
+
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    return {
+        "json": json_path,
+        "markdown": md_path,
+    }
+
+
+def _markdown_cell(value):
+    return str(value).replace("|", "\\|").replace("\n", " ")
 
 
 def choose_aac_bitrate(audio_info):

--- a/process_music.py
+++ b/process_music.py
@@ -16,10 +16,12 @@ from musiclib.convert import (
 )
 from musiclib.analyze import (
     analyze_gain,
+    audit_quality,
     choose_aac_bitrate,
     decide_encoding_strategy,
     get_audio_info,
-    run_rsgain
+    run_rsgain,
+    write_quality_audit_reports,
 )
 from musiclib.artwork import extract_embedded_artwork
 from musiclib.metadata_audit import (
@@ -280,6 +282,11 @@ def run_metadata_audit_command(args):
     print(f"Metadata audit saved to:\n- {reports['json']}\n- {reports['markdown']}")
 
 
+def run_quality_audit_command(args):
+    reports = write_quality_audit_reports(audit_quality(args.input), args.output)
+    print(f"Quality audit saved to:\n- {reports['json']}\n- {reports['markdown']}")
+
+
 def run_filename_plan_command(args):
     plan = build_filename_normalization_plan(audit_metadata(args.input))
     reports = write_filename_plan_reports(plan, args.output)
@@ -327,6 +334,11 @@ def build_parser():
     metadata_parser.add_argument("input", help="Path to input directory")
     metadata_parser.add_argument("output", help="Path to output directory")
     metadata_parser.set_defaults(handler=run_metadata_audit_command)
+
+    quality_parser = subparsers.add_parser("quality-audit", help="Write read-only source quality audit reports.")
+    quality_parser.add_argument("input", help="Path to input directory")
+    quality_parser.add_argument("output", help="Path to output directory")
+    quality_parser.set_defaults(handler=run_quality_audit_command)
 
     filename_plan_parser = subparsers.add_parser("filename-plan", help="Write a read-only filename normalization plan.")
     filename_plan_parser.add_argument("input", help="Path to input directory")

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,11 +1,16 @@
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
 from musiclib.analyze import (
     _get_tag_value,
+    analyze_quality,
+    audit_quality,
     choose_aac_bitrate,
     decide_encoding_strategy,
     run_rsgain,
+    write_quality_audit_reports,
 )
 
 
@@ -114,6 +119,130 @@ class ReplayGainTests(unittest.TestCase):
         tags = {"----:com.apple.iTunes:replaygain_track_gain": [b"-7.25 dB"]}
 
         self.assertEqual(_get_tag_value(tags, "replaygain_track_gain"), "-7.25 dB")
+
+
+class QualityAuditTests(unittest.TestCase):
+    def test_analyze_quality_flags_low_bitrate_lossy(self):
+        with patch("musiclib.analyze.get_audio_info", return_value={
+            "ext": ".mp3",
+            "sample_rate": 44100,
+            "bits_per_sample": None,
+            "bitrate": 128,
+            "duration": 180,
+            "codec": None,
+            "codec_description": "MP3",
+            "parser": "mp3",
+        }), patch("musiclib.analyze.analyze_gain", return_value=gain_info()):
+            result = analyze_quality("/music/song.mp3", root_dir="/music")
+
+        self.assertTrue(result["resourcing_recommended"])
+        self.assertIn("low_bitrate_lossy", result["reasons"])
+
+    def test_analyze_quality_reports_decode_errors(self):
+        with patch("musiclib.analyze.get_audio_info", side_effect=RuntimeError("bad file")), \
+                patch("musiclib.analyze.analyze_gain", side_effect=RuntimeError("bad file")):
+            result = analyze_quality("/music/bad.mp3", root_dir="/music")
+
+        self.assertTrue(result["resourcing_recommended"])
+        self.assertEqual(result["error"], "bad file")
+        self.assertIn("decode_error", result["reasons"])
+
+    def test_analyze_quality_flags_suspicious_flac_bitrate(self):
+        with patch("musiclib.analyze.get_audio_info", return_value={
+            "ext": ".flac",
+            "sample_rate": 44100,
+            "bits_per_sample": 16,
+            "bitrate": 500,
+            "duration": 180,
+            "codec": "flac",
+            "codec_description": "FLAC",
+            "parser": "flac",
+        }), patch("musiclib.analyze.analyze_gain", return_value=gain_info()):
+            result = analyze_quality("/music/song.flac", root_dir="/music")
+
+        self.assertTrue(result["resourcing_recommended"])
+        self.assertIn("suspicious_lossless_bitrate", result["reasons"])
+
+    def test_analyze_quality_missing_replaygain_does_not_recommend_resourcing(self):
+        with patch("musiclib.analyze.get_audio_info", return_value={
+            "ext": ".mp3",
+            "sample_rate": 44100,
+            "bits_per_sample": None,
+            "bitrate": 320,
+            "duration": 180,
+            "codec": None,
+            "codec_description": "MP3",
+            "parser": "mp3",
+        }), patch("musiclib.analyze.analyze_gain", return_value=gain_info(track_gain=None)):
+            result = analyze_quality("/music/song.mp3", root_dir="/music")
+
+        self.assertFalse(result["resourcing_recommended"])
+        self.assertIn("missing_replaygain", result["reasons"])
+
+    def test_analyze_quality_very_short_track_does_not_recommend_resourcing(self):
+        with patch("musiclib.analyze.get_audio_info", return_value={
+            "ext": ".mp3",
+            "sample_rate": 44100,
+            "bits_per_sample": None,
+            "bitrate": 320,
+            "duration": 20,
+            "codec": None,
+            "codec_description": "MP3",
+            "parser": "mp3",
+        }), patch("musiclib.analyze.analyze_gain", return_value=gain_info()):
+            result = analyze_quality("/music/song.mp3", root_dir="/music")
+
+        self.assertFalse(result["resourcing_recommended"])
+        self.assertIn("very_short_track", result["reasons"])
+
+    def test_audit_quality_scans_audio_files(self):
+        with patch("musiclib.analyze.iter_quality_audio_files", return_value=["/music/a.mp3", "/music/b.flac"]), \
+                patch("musiclib.analyze.analyze_quality", side_effect=[
+                    {"resourcing_recommended": False},
+                    {"resourcing_recommended": True},
+                ]):
+            audit = audit_quality("/music")
+
+        self.assertEqual(audit["track_count"], 2)
+        self.assertEqual(audit["flagged_count"], 1)
+
+    def test_writes_quality_audit_reports(self):
+        audit = {
+            "root_dir": "/music",
+            "track_count": 1,
+            "flagged_count": 1,
+            "tracks": [
+                {
+                    "relative_path": "Artist/Album/song.mp3",
+                    "resourcing_recommended": True,
+                    "codec_description": "MP3",
+                    "codec": None,
+                    "parser": "mp3",
+                    "bitrate": 128,
+                    "sample_rate": 44100,
+                    "reasons": ["low_bitrate_lossy"],
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = write_quality_audit_reports(audit, tmpdir)
+
+            self.assertTrue(os.path.exists(reports["json"]))
+            self.assertTrue(os.path.exists(reports["markdown"]))
+
+
+def gain_info(track_gain=-7.0, track_peak=0.9):
+    return {
+        "path": "/music/song.mp3",
+        "track_gain": track_gain,
+        "album_gain": None,
+        "track_peak": track_peak,
+        "album_peak": None,
+        "too_quiet": False,
+        "potential_clipping": track_peak is not None and track_peak >= 1.0,
+        "resourcing_recommended": False,
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_process_music_cli.py
+++ b/tests/test_process_music_cli.py
@@ -32,6 +32,13 @@ class ProcessMusicCliTests(unittest.TestCase):
         self.assertEqual(args.input, "input")
         self.assertEqual(args.output, "output")
 
+    def test_quality_audit_subcommand_parses_paths(self):
+        args = build_parser().parse_args(["quality-audit", "input", "output"])
+
+        self.assertEqual(args.command, "quality-audit")
+        self.assertEqual(args.input, "input")
+        self.assertEqual(args.output, "output")
+
     def test_filename_plan_subcommand_parses_paths(self):
         args = build_parser().parse_args(["filename-plan", "input", "output"])
 


### PR DESCRIPTION
## Summary
- add a quality-audit subcommand that writes quality_audit.json and quality_audit.md
- flag low-bitrate lossy files, suspicious low-bitrate FLACs, low sample rates, short tracks, clipping, decode errors, and missing ReplayGain tags
- keep missing ReplayGain and very short tracks as report-only reasons rather than automatic re-source recommendations
- add tests for quality reasons, decode errors, report writing, and CLI parsing

## Tests
- /private/tmp/musicprocessor-venv/bin/python -m unittest discover -s tests
- /private/tmp/musicprocessor-venv/bin/python -m compileall process_music.py musiclib tests
- git diff --check